### PR TITLE
Maintainer update: Switch GH Account 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,4 +68,4 @@ extra:
   recipe-maintainers:
     - jan-janssen
     - carlodri
-    - ThomasMarwitzQC
+    - thomasmarwitz


### PR DESCRIPTION
I'm switching from my company account to my private account soon-ish. The company account will be deleted then.

To keep maintaining this project, I've exchanged the old company account for my personal one.